### PR TITLE
QReader.uno: Fix initialize order to fix NRE

### DIFF
--- a/Qreader.uno
+++ b/Qreader.uno
@@ -57,8 +57,8 @@ public class QreaderImpl
 			 if (_intentListener == null)
 				_intentListener = Init();
 		}
-		ScannerImpl();
 		FutureResult = new Promise<string>();
+		ScannerImpl();
 		return FutureResult;
 	}
 


### PR DESCRIPTION
`FutureResult` is used in `void Cancelled`, and that method can be called before `ScannerImpl` has returned. This could cause null pointer crashes, under some circumstances.